### PR TITLE
[DO-286] Add var: root_block_device

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,12 +60,12 @@ EOF
   dynamic "root_block_device" {
     for_each = var.root_block_device
     content {
-      volume_type           = lookup(root_block_device.value, "volume_type", null)
-      volume_size           = lookup(root_block_device.value, "volume_size", null)
-      iops                  = lookup(root_block_device.value, "iops", null)
-      throughput            = lookup(root_block_device.value, "throughput", null)
-      delete_on_termination = lookup(root_block_device.value, "delete_on_termination", null)
-      encrypted             = lookup(root_block_device.value, "encrypted", null)
+      volume_type           = try(root_block_device.value.volume_type, null)
+      volume_size           = try(root_block_device.value.volume_size, null)
+      iops                  = try(root_block_device.value.iops, null)
+      throughput            = try(root_block_device.value.throughput, null)
+      delete_on_termination = try(root_block_device.value.delete_on_termination, true)
+      encrypted             = try(root_block_device.value.encrypted, false)
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,18 @@ echo 'ECS_CLUSTER=${var.name}' >> /etc/ecs/ecs.config
 echo 'ECS_DISABLE_PRIVILEGED=true' >> /etc/ecs/ecs.config
 EOF
 
+  dynamic "root_block_device" {
+    for_each = var.root_block_device
+    content {
+      volume_type           = lookup(root_block_device.value, "volume_type", null)
+      volume_size           = lookup(root_block_device.value, "volume_size", null)
+      iops                  = lookup(root_block_device.value, "iops", null)
+      throughput            = lookup(root_block_device.value, "throughput", null)
+      delete_on_termination = lookup(root_block_device.value, "delete_on_termination", null)
+      encrypted             = lookup(root_block_device.value, "encrypted", null)
+    }
+  }
+
   lifecycle {
     create_before_destroy = true
   }

--- a/variables.tf
+++ b/variables.tf
@@ -73,14 +73,7 @@ variable "enable_container_insights" {
 }
 
 variable "root_block_device" {
-  type    = list(object({
-    volume_type = string
-    volume_size = number
-    iops = number
-    throughput = number
-    delete_on_termination = bool
-    encrypted = bool
-  }))
+  type    = list(any)
   default = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -72,6 +72,18 @@ variable "enable_container_insights" {
   default = true
 }
 
+variable "root_block_device" {
+  type    = list(object({
+    volume_type = string
+    volume_size = number
+    iops = number
+    throughput = number
+    delete_on_termination = bool
+    encrypted = bool
+  }))
+  default = []
+}
+
 variable "tags" {
   type    = map(string)
   default = {}


### PR DESCRIPTION
# 개요
- `launch_configuration` 내 `root_block_device` 추가
- dynamic 블록 추가: 기존 코드와의 호환성 유지
- 로컬 환경에서 `tg validate` 및 `tg plan` 테스트 성공